### PR TITLE
Update styling to Laravel formatting and fix test method typo

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,13 +1,12 @@
 <?php
 
-
 function dump()
 {
     foreach (func_get_args() as $arg) {
         if (php_sapi_name() === 'cli') {
-            print print_r($arg, true) . PHP_EOL;
+            echo print_r($arg, true).PHP_EOL;
         } else {
-            print '<pre>' . htmlspecialchars(print_r($arg, true)) . '</pre>';
+            echo '<pre>'.htmlspecialchars(print_r($arg, true)).'</pre>';
         }
     }
 }
@@ -17,7 +16,6 @@ function dd()
     call_user_func_array('dump', func_get_args());
     die();
 }
-
 
 require_once 'vendor/autoload.php';
 
@@ -34,19 +32,19 @@ $el = new YeTii\HtmlElement\Elements\Select([
         new YeTii\HtmlElement\Elements\Option([
             'value' => 1,
             'node' => 'AB Web',
-            'selected' => null
+            'selected' => null,
         ]),
         new YeTii\HtmlElement\Elements\Option([
             'value' => 2,
             'node' => 'Test Organisation',
-            'selected' => true
+            'selected' => true,
         ]),
         new YeTii\HtmlElement\Elements\Option([
             'value' => 3,
             'node' => 'Google',
             'selected' => null,
         ]),
-    ]
+    ],
 ]);
 
 // $el = new YeTii\HtmlElement\Elements\Textarea([
@@ -55,9 +53,9 @@ $el = new YeTii\HtmlElement\Elements\Select([
 //     'node' => 'This is the value',
 // ]);
 
-print htmlspecialchars($el->render());
+echo htmlspecialchars($el->render());
 
-print '<pre>';
+echo '<pre>';
 print_r($el);
 
 die();
@@ -142,31 +140,31 @@ $attributesForElements = [
     'ol' => ['reversed', 'start'],
     'menu' => ['type'],
     'data' => ['value'],
-    'li' => ['value']
+    'li' => ['value'],
 ];
 
 $globalAttributes = [
-    "accesskey",
-    "autocapitalize",
-    "class",
-    "contenteditable",
-    "contextmenu",
-    "data-*",
-    "dir",
-    "draggable",
-    "dropzone",
-    "hidden",
-    "id",
-    "itemprop",
-    "lang",
-    "slot",
-    "spellcheck",
-    "style",
-    "tabindex",
-    "title",
-    "translate",
-    "enterkeyhint",
-    "inputmode"
+    'accesskey',
+    'autocapitalize',
+    'class',
+    'contenteditable',
+    'contextmenu',
+    'data-*',
+    'dir',
+    'draggable',
+    'dropzone',
+    'hidden',
+    'id',
+    'itemprop',
+    'lang',
+    'slot',
+    'spellcheck',
+    'style',
+    'tabindex',
+    'title',
+    'translate',
+    'enterkeyhint',
+    'inputmode',
 ];
 
 foreach (scandir($dir) as $file) {
@@ -174,7 +172,7 @@ foreach (scandir($dir) as $file) {
         continue;
     }
 
-    $path = $dir . $file;
+    $path = $dir.$file;
 
     $clName = str_replace('.php', '', $file);
     $name = strtolower($clName);

--- a/src/Element.php
+++ b/src/Element.php
@@ -2,11 +2,10 @@
 
 namespace YeTii\HtmlElement;
 
-use YeTii\HtmlElement\Exceptions\InvalidAttributeException;
-use YeTii\HtmlElement\Interfaces\HasTextChild;
-use YeTii\HtmlElement\Interfaces\IsSingleton;
 use YeTii\HtmlElement\Interfaces\IsTextNode;
-use YeTii\HtmlElement\TextNode;
+use YeTii\HtmlElement\Interfaces\IsSingleton;
+use YeTii\HtmlElement\Interfaces\HasTextChild;
+use YeTii\HtmlElement\Exceptions\InvalidAttributeException;
 
 class Element
 {
@@ -19,7 +18,7 @@ class Element
     protected $name;
 
     /**
-     * List of current attributes for this Element
+     * List of current attributes for this Element.
      *
      * @var array
      */
@@ -34,7 +33,7 @@ class Element
     protected $availableAttributes = [];
 
     /**
-     * List of Elements in this Element's child nodes
+     * List of Elements in this Element's child nodes.
      *
      * @var array
      */
@@ -42,7 +41,7 @@ class Element
 
     /**
      * List of attributes which do not require a value. The existence of
-     * the attribute means true, while the absense means false
+     * the attribute means true, while the absense means false.
      *
      * @var array
      */
@@ -58,12 +57,12 @@ class Element
      * Indicator whether or not to render text contents as raw or
      * htmlspecialchar'd. Null indicates inheritance, if applicable.
      *
-     * @var boolean
+     * @var bool
      */
     protected $escapeHtml = null;
 
     /**
-     * Create a new Element
+     * Create a new Element.
      *
      * @param array $args List of attributes (and/or nodes)
      * @param string $name Optional name to set for this element, used for rendering
@@ -90,7 +89,7 @@ class Element
      * @param string $name The name of the element
      * @return Element
      */
-    public function setName(string $name): Element
+    public function setName(string $name): self
     {
         $this->name = $name;
 
@@ -98,7 +97,7 @@ class Element
     }
 
     /**
-     * Return the name of the element
+     * Return the name of the element.
      *
      * @return string
      */
@@ -108,12 +107,12 @@ class Element
     }
 
     /**
-     * Bulk set attributes (and nodes) for this element
+     * Bulk set attributes (and nodes) for this element.
      *
      * @param array $args List of attributes (and/or nodes)
      * @return Element
      */
-    public function set(array $args): Element
+    public function set(array $args): self
     {
         foreach ($args as $key => $value) {
             $this->setAttribute($key, $value);
@@ -124,13 +123,13 @@ class Element
 
     /**
      * Set an attribute name and value for this element, or add one or more
-     * child elements to this element's child nodes
+     * child elements to this element's child nodes.
      *
      * @param string $key The name of the attribute
      * @param mixed $value The value of the attribute
      * @return Element
      */
-    public function setAttribute(string $key, $value): Element
+    public function setAttribute(string $key, $value): self
     {
         if ($key === 'nodes' || $key === 'node') {
             return $this->addChildren((array) $value);
@@ -142,16 +141,16 @@ class Element
             return $this;
         }
 
-        throw new InvalidAttributeException('Invalid `' . $this->name . '` attribute name: ' . $key);
+        throw new InvalidAttributeException('Invalid `'.$this->name.'` attribute name: '.$key);
     }
 
     /**
-     * Append multiple elements to this element's child nodes
+     * Append multiple elements to this element's child nodes.
      *
      * @param array $children List of child elements
      * @return Element
      */
-    public function addChildren(array $children): Element
+    public function addChildren(array $children): self
     {
         foreach ($children as $child) {
             if (is_string($child)) {
@@ -167,12 +166,12 @@ class Element
     }
 
     /**
-     * Append an element to this element's child nodes
+     * Append an element to this element's child nodes.
      *
      * @param Element $child A child Element
      * @return Element
      */
-    public function addChild(Element $child): Element
+    public function addChild(self $child): self
     {
         $this->children[] = $child;
 
@@ -180,7 +179,7 @@ class Element
     }
 
     /**
-     * Render any given element in its entirety
+     * Render any given element in its entirety.
      *
      * @return string
      */
@@ -197,21 +196,21 @@ class Element
         }
 
         $html = [
-            '<' . $this->name,
+            '<'.$this->name,
         ];
 
         foreach ($this->attributes as $key => $value) {
             if (in_array($key, $this->booleanAttributes)) {
-                if (!$value) {
+                if (! $value) {
                     continue;
                 }
 
-                $html[] = ' ' . $key;
+                $html[] = ' '.$key;
                 continue;
             }
 
             if ($value === null) {
-                $html[] = ' ' . $key;
+                $html[] = ' '.$key;
                 continue;
             }
 
@@ -229,7 +228,7 @@ EOL;
 
             $html[] = $this->renderChildren();
 
-            $html[] = '</' . $this->name . '>';
+            $html[] = '</'.$this->name.'>';
         }
 
         $html = implode('', $html);
@@ -238,7 +237,7 @@ EOL;
     }
 
     /**
-     * Render all child elements of any given element as a string
+     * Render all child elements of any given element as a string.
      *
      * @return string
      */
@@ -261,13 +260,13 @@ EOL;
 
     /**
      * Specify whether or not to render this Element's text nodes
-     * are raw or htmlspecialchar'd
+     * are raw or htmlspecialchar'd.
      *
      * @param  bool  $escapeHtml
      * @param  bool  $inheritFalse
      * @return Element
      */
-    public function escapeHtml(bool $escapeHtml = true, $inheritFalse = false): Element
+    public function escapeHtml(bool $escapeHtml = true, $inheritFalse = false): self
     {
         // If explictly set to false (i.e. not null) and should retain that false
         if ($this->escapeHtml === false && $inheritFalse) {

--- a/src/Element.php
+++ b/src/Element.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace YeTii\HtmlElement;
 
 use YeTii\HtmlElement\Exceptions\InvalidAttributeException;
@@ -9,7 +10,6 @@ use YeTii\HtmlElement\TextNode;
 
 class Element
 {
-
     /**
      * Optional name for the element, should PHP class naming forbid the
      * element name. Defaults to the Element's PHP class name.
@@ -263,7 +263,8 @@ EOL;
      * Specify whether or not to render this Element's text nodes
      * are raw or htmlspecialchar'd
      *
-     * @param boolean $escape Enable or disable escaping of HTML?
+     * @param  bool  $escapeHtml
+     * @param  bool  $inheritFalse
      * @return Element
      */
     public function escapeHtml(bool $escapeHtml = true, $inheritFalse = false): Element

--- a/src/Elements/A.php
+++ b/src/Elements/A.php
@@ -1,11 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
 
 class A extends Element
 {
-
     protected $name = 'a';
 
     protected $availableAttributes = [
@@ -39,5 +39,4 @@ class A extends Element
         'shape',
         'target',
     ];
-
 }

--- a/src/Elements/Abbr.php
+++ b/src/Elements/Abbr.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Abbr extends Element
 {
-
     protected $name = 'abbr';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class Abbr extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Address.php
+++ b/src/Elements/Address.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Address extends Element
 {
-
     protected $name = 'address';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class Address extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Area.php
+++ b/src/Elements/Area.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
@@ -6,7 +7,6 @@ use YeTii\HtmlElement\Interfaces\IsSingleton;
 
 class Area extends Element implements IsSingleton
 {
-
     protected $name = 'area';
 
     protected $availableAttributes = [
@@ -40,7 +40,6 @@ class Area extends Element implements IsSingleton
         'referrerpolicy',
         'rel',
         'shape',
-        'target'
+        'target',
     ];
-
 }

--- a/src/Elements/Article.php
+++ b/src/Elements/Article.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Article extends Element
 {
-
     protected $name = 'article';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class Article extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Aside.php
+++ b/src/Elements/Aside.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Aside extends Element
 {
-
     protected $name = 'aside';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class Aside extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Audio.php
+++ b/src/Elements/Audio.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Audio extends Element
 {
-
     protected $name = 'audio';
 
     protected $availableAttributes = [
@@ -37,7 +36,6 @@ class Audio extends Element
         'loop',
         'muted',
         'preload',
-        'src'
+        'src',
     ];
-
 }

--- a/src/Elements/B.php
+++ b/src/Elements/B.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class B extends Element
 {
-
     protected $name = 'b';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class B extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Bdi.php
+++ b/src/Elements/Bdi.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Bdi extends Element
 {
-
     protected $name = 'bdi';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class Bdi extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Bdo.php
+++ b/src/Elements/Bdo.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Bdo extends Element
 {
-
     protected $name = 'bdo';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class Bdo extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Blockquote.php
+++ b/src/Elements/Blockquote.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Blockquote extends Element
 {
-
     protected $name = 'blockquote';
 
     protected $availableAttributes = [
@@ -30,7 +29,6 @@ class Blockquote extends Element
         'translate',
         'enterkeyhint',
         'inputmode',
-        'cite'
+        'cite',
     ];
-
 }

--- a/src/Elements/Body.php
+++ b/src/Elements/Body.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Body extends Element
 {
-
     protected $name = 'body';
 
     protected $availableAttributes = [
@@ -31,7 +30,6 @@ class Body extends Element
         'enterkeyhint',
         'inputmode',
         'background',
-        'bgcolor'
+        'bgcolor',
     ];
-
 }

--- a/src/Elements/Br.php
+++ b/src/Elements/Br.php
@@ -7,7 +7,6 @@ use YeTii\HtmlElement\Interfaces\IsSingleton;
 
 class Br extends Element implements IsSingleton
 {
-
     protected $name = 'br';
 
     protected $availableAttributes = [
@@ -30,7 +29,6 @@ class Br extends Element implements IsSingleton
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Button.php
+++ b/src/Elements/Button.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Button extends Element
 {
-
     protected $name = 'button';
 
     protected $availableAttributes = [
@@ -40,7 +39,6 @@ class Button extends Element
         'formtarget',
         'name',
         'type',
-        'value'
+        'value',
     ];
-
 }

--- a/src/Elements/Canvas.php
+++ b/src/Elements/Canvas.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Canvas extends Element
 {
-
     protected $name = 'canvas';
 
     protected $availableAttributes = [
@@ -31,7 +30,6 @@ class Canvas extends Element
         'enterkeyhint',
         'inputmode',
         'height',
-        'width'
+        'width',
     ];
-
 }

--- a/src/Elements/Caption.php
+++ b/src/Elements/Caption.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Caption extends Element
 {
-
     protected $name = 'caption';
 
     protected $availableAttributes = [
@@ -30,7 +29,6 @@ class Caption extends Element
         'translate',
         'enterkeyhint',
         'inputmode',
-        'align'
+        'align',
     ];
-
 }

--- a/src/Elements/Cite.php
+++ b/src/Elements/Cite.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Cite extends Element
 {
-
     protected $name = 'cite';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class Cite extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Code.php
+++ b/src/Elements/Code.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Code extends Element
 {
-
     protected $name = 'code';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class Code extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Col.php
+++ b/src/Elements/Col.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
@@ -6,7 +7,6 @@ use YeTii\HtmlElement\Interfaces\IsSingleton;
 
 class Col extends Element implements IsSingleton
 {
-
     protected $name = 'col';
 
     protected $availableAttributes = [
@@ -32,7 +32,6 @@ class Col extends Element implements IsSingleton
         'inputmode',
         'align',
         'bgcolor',
-        'span'
+        'span',
     ];
-
 }

--- a/src/Elements/Colgroup.php
+++ b/src/Elements/Colgroup.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Colgroup extends Element
 {
-
     protected $name = 'colgroup';
 
     protected $availableAttributes = [
@@ -32,7 +31,6 @@ class Colgroup extends Element
         'inputmode',
         'align',
         'bgcolor',
-        'span'
+        'span',
     ];
-
 }

--- a/src/Elements/Command.php
+++ b/src/Elements/Command.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
@@ -6,7 +7,6 @@ use YeTii\HtmlElement\Interfaces\IsSingleton;
 
 class Command extends Element implements IsSingleton
 {
-
     protected $name = 'command';
 
     protected $availableAttributes = [
@@ -34,7 +34,6 @@ class Command extends Element implements IsSingleton
         'disabled',
         'icon',
         'radiogroup',
-        'type'
+        'type',
     ];
-
 }

--- a/src/Elements/Datalist.php
+++ b/src/Elements/Datalist.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Datalist extends Element
 {
-
     protected $name = 'datalist';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class Datalist extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Dd.php
+++ b/src/Elements/Dd.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Dd extends Element
 {
-
     protected $name = 'dd';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class Dd extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Del.php
+++ b/src/Elements/Del.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Del extends Element
 {
-
     protected $name = 'del';
 
     protected $availableAttributes = [
@@ -31,7 +30,6 @@ class Del extends Element
         'enterkeyhint',
         'inputmode',
         'cite',
-        'datetime'
+        'datetime',
     ];
-
 }

--- a/src/Elements/Details.php
+++ b/src/Elements/Details.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Details extends Element
 {
-
     protected $name = 'details';
 
     protected $availableAttributes = [
@@ -30,7 +29,6 @@ class Details extends Element
         'translate',
         'enterkeyhint',
         'inputmode',
-        'open'
+        'open',
     ];
-
 }

--- a/src/Elements/Dfn.php
+++ b/src/Elements/Dfn.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Dfn extends Element
 {
-
     protected $name = 'dfn';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class Dfn extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Div.php
+++ b/src/Elements/Div.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Div extends Element
 {
-
     protected $availableAttributes = [
         'accesskey',
         'autocapitalize',
@@ -27,7 +26,6 @@ class Div extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Dl.php
+++ b/src/Elements/Dl.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Dl extends Element
 {
-
     protected $name = 'dl';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class Dl extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Dt.php
+++ b/src/Elements/Dt.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Dt extends Element
 {
-
     protected $name = 'dt';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class Dt extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Em.php
+++ b/src/Elements/Em.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Em extends Element
 {
-
     protected $name = 'em';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class Em extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Embed.php
+++ b/src/Elements/Embed.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
@@ -6,7 +7,6 @@ use YeTii\HtmlElement\Interfaces\IsSingleton;
 
 class Embed extends Element implements IsSingleton
 {
-
     protected $name = 'embed';
 
     protected $availableAttributes = [
@@ -33,7 +33,6 @@ class Embed extends Element implements IsSingleton
         'height',
         'src',
         'type',
-        'width'
+        'width',
     ];
-
 }

--- a/src/Elements/Fieldset.php
+++ b/src/Elements/Fieldset.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Fieldset extends Element
 {
-
     protected $name = 'fieldset';
 
     protected $availableAttributes = [
@@ -32,7 +31,6 @@ class Fieldset extends Element
         'inputmode',
         'disabled',
         'form',
-        'name'
+        'name',
     ];
-
 }

--- a/src/Elements/Figcaption.php
+++ b/src/Elements/Figcaption.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Figcaption extends Element
 {
-
     protected $name = 'figcaption';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class Figcaption extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Figure.php
+++ b/src/Elements/Figure.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Figure extends Element
 {
-
     protected $name = 'figure';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class Figure extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Footer.php
+++ b/src/Elements/Footer.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Footer extends Element
 {
-
     protected $name = 'footer';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class Footer extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Form.php
+++ b/src/Elements/Form.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Form extends Element
 {
-
     protected $name = 'form';
 
     protected $availableAttributes = [
@@ -38,7 +37,6 @@ class Form extends Element
         'method',
         'name',
         'novalidate',
-        'target'
+        'target',
     ];
-
 }

--- a/src/Elements/H1.php
+++ b/src/Elements/H1.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class H1 extends Element
 {
-
     protected $name = 'h1';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class H1 extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/H2.php
+++ b/src/Elements/H2.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class H2 extends Element
 {
-
     protected $name = 'h2';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class H2 extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/H3.php
+++ b/src/Elements/H3.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class H3 extends Element
 {
-
     protected $name = 'h3';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class H3 extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/H4.php
+++ b/src/Elements/H4.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class H4 extends Element
 {
-
     protected $name = 'h4';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class H4 extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/H5.php
+++ b/src/Elements/H5.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class H5 extends Element
 {
-
     protected $name = 'h5';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class H5 extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/H6.php
+++ b/src/Elements/H6.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class H6 extends Element
 {
-
     protected $name = 'h6';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class H6 extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Head.php
+++ b/src/Elements/Head.php
@@ -3,11 +3,9 @@
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Head extends Element
 {
-
     protected $name = 'head';
 
     protected $availableAttributes = [
@@ -30,7 +28,6 @@ class Head extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Header.php
+++ b/src/Elements/Header.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Header extends Element
 {
-
     protected $name = 'header';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class Header extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Hr.php
+++ b/src/Elements/Hr.php
@@ -7,7 +7,6 @@ use YeTii\HtmlElement\Interfaces\IsSingleton;
 
 class Hr extends Element implements IsSingleton
 {
-
     protected $name = 'hr';
 
     protected $availableAttributes = [
@@ -32,7 +31,6 @@ class Hr extends Element implements IsSingleton
         'enterkeyhint',
         'inputmode',
         'align',
-        'color'
+        'color',
     ];
-
 }

--- a/src/Elements/Html.php
+++ b/src/Elements/Html.php
@@ -3,11 +3,9 @@
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Html extends Element
 {
-
     protected $name = 'html';
 
     protected $availableAttributes = [
@@ -31,7 +29,6 @@ class Html extends Element
         'translate',
         'enterkeyhint',
         'inputmode',
-        'manifest'
+        'manifest',
     ];
-
 }

--- a/src/Elements/I.php
+++ b/src/Elements/I.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class I extends Element
 {
-
     protected $name = 'i';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class I extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Iframe.php
+++ b/src/Elements/Iframe.php
@@ -3,11 +3,9 @@
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Iframe extends Element
 {
-
     protected $name = 'iframe';
 
     protected $availableAttributes = [
@@ -42,7 +40,6 @@ class Iframe extends Element
         'sandbox',
         'src',
         'srcdoc',
-        'width'
+        'width',
     ];
-
 }

--- a/src/Elements/Img.php
+++ b/src/Elements/Img.php
@@ -7,7 +7,6 @@ use YeTii\HtmlElement\Interfaces\IsSingleton;
 
 class Img extends Element implements IsSingleton
 {
-
     protected $name = 'img';
 
     protected $availableAttributes = [
@@ -46,7 +45,6 @@ class Img extends Element implements IsSingleton
         'src',
         'srcset',
         'usemap',
-        'width'
+        'width',
     ];
-
 }

--- a/src/Elements/Input.php
+++ b/src/Elements/Input.php
@@ -3,12 +3,10 @@
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 use YeTii\HtmlElement\Interfaces\IsSingleton;
 
 class Input extends Element implements IsSingleton
 {
-
     protected $name = 'input';
 
     protected $availableAttributes = [
@@ -63,7 +61,6 @@ class Input extends Element implements IsSingleton
         'type',
         'usemap',
         'value',
-        'width'
+        'width',
     ];
-
 }

--- a/src/Elements/Ins.php
+++ b/src/Elements/Ins.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Ins extends Element
 {
-
     protected $name = 'ins';
 
     protected $availableAttributes = [
@@ -31,7 +30,6 @@ class Ins extends Element
         'enterkeyhint',
         'inputmode',
         'cite',
-        'datetime'
+        'datetime',
     ];
-
 }

--- a/src/Elements/Kbd.php
+++ b/src/Elements/Kbd.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Kbd extends Element
 {
-
     protected $name = 'kbd';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class Kbd extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Keygen.php
+++ b/src/Elements/Keygen.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
@@ -6,7 +7,6 @@ use YeTii\HtmlElement\Interfaces\IsSingleton;
 
 class Keygen extends Element implements IsSingleton
 {
-
     protected $name = 'keygen';
 
     protected $availableAttributes = [
@@ -35,7 +35,6 @@ class Keygen extends Element implements IsSingleton
         'disabled',
         'form',
         'keytype',
-        'name'
+        'name',
     ];
-
 }

--- a/src/Elements/Label.php
+++ b/src/Elements/Label.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Label extends Element
 {
-
     protected $name = 'label';
 
     protected $availableAttributes = [
@@ -31,7 +30,6 @@ class Label extends Element
         'enterkeyhint',
         'inputmode',
         'for',
-        'form'
+        'form',
     ];
-
 }

--- a/src/Elements/Legend.php
+++ b/src/Elements/Legend.php
@@ -3,11 +3,9 @@
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Legend extends Element
 {
-
     protected $name = 'legend';
 
     protected $availableAttributes = [
@@ -30,7 +28,6 @@ class Legend extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Li.php
+++ b/src/Elements/Li.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Li extends Element
 {
-
     protected $name = 'li';
 
     protected $availableAttributes = [
@@ -30,7 +29,6 @@ class Li extends Element
         'translate',
         'enterkeyhint',
         'inputmode',
-        'value'
+        'value',
     ];
-
 }

--- a/src/Elements/Main.php
+++ b/src/Elements/Main.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Main extends Element
 {
-
     protected $name = 'main';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class Main extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Map.php
+++ b/src/Elements/Map.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Map extends Element
 {
-
     protected $name = 'map';
 
     protected $availableAttributes = [
@@ -30,7 +29,6 @@ class Map extends Element
         'translate',
         'enterkeyhint',
         'inputmode',
-        'name'
+        'name',
     ];
-
 }

--- a/src/Elements/Mark.php
+++ b/src/Elements/Mark.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Mark extends Element
 {
-
     protected $name = 'mark';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class Mark extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Menu.php
+++ b/src/Elements/Menu.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Menu extends Element
 {
-
     protected $name = 'menu';
 
     protected $availableAttributes = [
@@ -30,7 +29,6 @@ class Menu extends Element
         'translate',
         'enterkeyhint',
         'inputmode',
-        'type'
+        'type',
     ];
-
 }

--- a/src/Elements/Meter.php
+++ b/src/Elements/Meter.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Meter extends Element
 {
-
     protected $name = 'meter';
 
     protected $availableAttributes = [
@@ -36,7 +35,6 @@ class Meter extends Element
         'max',
         'min',
         'optimum',
-        'value'
+        'value',
     ];
-
 }

--- a/src/Elements/Nav.php
+++ b/src/Elements/Nav.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Nav extends Element
 {
-
     protected $name = 'nav';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class Nav extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Object.php
+++ b/src/Elements/Object.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Object extends Element
 {
-
     protected $name = 'object';
 
     protected $availableAttributes = [
@@ -37,7 +36,6 @@ class Object extends Element
         'name',
         'type',
         'usemap',
-        'width'
+        'width',
     ];
-
 }

--- a/src/Elements/Ol.php
+++ b/src/Elements/Ol.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Ol extends Element
 {
-
     protected $name = 'ol';
 
     protected $availableAttributes = [
@@ -31,7 +30,6 @@ class Ol extends Element
         'enterkeyhint',
         'inputmode',
         'reversed',
-        'start'
+        'start',
     ];
-
 }

--- a/src/Elements/Optgroup.php
+++ b/src/Elements/Optgroup.php
@@ -3,11 +3,9 @@
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Optgroup extends Element
 {
-
     protected $name = 'optgroup';
 
     protected $availableAttributes = [
@@ -31,6 +29,6 @@ class Optgroup extends Element
         'translate',
         'enterkeyhint',
         'inputmode',
-        'disabled'
+        'disabled',
     ];
 }

--- a/src/Elements/Option.php
+++ b/src/Elements/Option.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Option extends Element
 {
-
     protected $name = 'option';
 
     protected $availableAttributes = [
@@ -32,7 +31,6 @@ class Option extends Element
         'inputmode',
         'disabled',
         'selected',
-        'value'
+        'value',
     ];
-
 }

--- a/src/Elements/Output.php
+++ b/src/Elements/Output.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Output extends Element
 {
-
     protected $name = 'output';
 
     protected $availableAttributes = [
@@ -32,7 +31,6 @@ class Output extends Element
         'inputmode',
         'for',
         'form',
-        'name'
+        'name',
     ];
-
 }

--- a/src/Elements/P.php
+++ b/src/Elements/P.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class P extends Element
 {
-
     protected $name = 'p';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class P extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Param.php
+++ b/src/Elements/Param.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
@@ -6,7 +7,6 @@ use YeTii\HtmlElement\Interfaces\IsSingleton;
 
 class Param extends Element implements IsSingleton
 {
-
     protected $name = 'param';
 
     protected $availableAttributes = [
@@ -31,7 +31,6 @@ class Param extends Element implements IsSingleton
         'enterkeyhint',
         'inputmode',
         'name',
-        'value'
+        'value',
     ];
-
 }

--- a/src/Elements/Pre.php
+++ b/src/Elements/Pre.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Pre extends Element
 {
-
     protected $name = 'pre';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class Pre extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Progress.php
+++ b/src/Elements/Progress.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Progress extends Element
 {
-
     protected $name = 'progress';
 
     protected $availableAttributes = [
@@ -32,7 +31,6 @@ class Progress extends Element
         'inputmode',
         'form',
         'max',
-        'value'
+        'value',
     ];
-
 }

--- a/src/Elements/Q.php
+++ b/src/Elements/Q.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Q extends Element
 {
-
     protected $name = 'q';
 
     protected $availableAttributes = [
@@ -30,7 +29,6 @@ class Q extends Element
         'translate',
         'enterkeyhint',
         'inputmode',
-        'cite'
+        'cite',
     ];
-
 }

--- a/src/Elements/Rp.php
+++ b/src/Elements/Rp.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Rp extends Element
 {
-
     protected $name = 'rp';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class Rp extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Rt.php
+++ b/src/Elements/Rt.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Rt extends Element
 {
-
     protected $name = 'rt';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class Rt extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Ruby.php
+++ b/src/Elements/Ruby.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Ruby extends Element
 {
-
     protected $name = 'ruby';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class Ruby extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/S.php
+++ b/src/Elements/S.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class S extends Element
 {
-
     protected $name = 's';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class S extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Samp.php
+++ b/src/Elements/Samp.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Samp extends Element
 {
-
     protected $name = 'samp';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class Samp extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Section.php
+++ b/src/Elements/Section.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Section extends Element
 {
-
     protected $name = 'section';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class Section extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Select.php
+++ b/src/Elements/Select.php
@@ -3,11 +3,9 @@
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Select extends Element
 {
-
     protected $name = 'select';
 
     protected $availableAttributes = [
@@ -38,6 +36,6 @@ class Select extends Element
         'multiple',
         'name',
         'required',
-        'size'
+        'size',
     ];
 }

--- a/src/Elements/Small.php
+++ b/src/Elements/Small.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Small extends Element
 {
-
     protected $name = 'small';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class Small extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Source.php
+++ b/src/Elements/Source.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
@@ -6,7 +7,6 @@ use YeTii\HtmlElement\Interfaces\IsSingleton;
 
 class Source extends Element implements IsSingleton
 {
-
     protected $name = 'source';
 
     protected $availableAttributes = [
@@ -34,7 +34,6 @@ class Source extends Element implements IsSingleton
         'sizes',
         'src',
         'srcset',
-        'type'
+        'type',
     ];
-
 }

--- a/src/Elements/Span.php
+++ b/src/Elements/Span.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Span extends Element
 {
-
     protected $name = 'span';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class Span extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Strong.php
+++ b/src/Elements/Strong.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Strong extends Element
 {
-
     protected $name = 'strong';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class Strong extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Sub.php
+++ b/src/Elements/Sub.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Sub extends Element
 {
-
     protected $name = 'sub';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class Sub extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Summary.php
+++ b/src/Elements/Summary.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Summary extends Element
 {
-
     protected $name = 'summary';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class Summary extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Sup.php
+++ b/src/Elements/Sup.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Sup extends Element
 {
-
     protected $name = 'sup';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class Sup extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Table.php
+++ b/src/Elements/Table.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Table extends Element
 {
-
     protected $name = 'table';
 
     protected $availableAttributes = [
@@ -34,7 +33,6 @@ class Table extends Element
         'background',
         'bgcolor',
         'border',
-        'summary'
+        'summary',
     ];
-
 }

--- a/src/Elements/Tbody.php
+++ b/src/Elements/Tbody.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Tbody extends Element
 {
-
     protected $name = 'tbody';
 
     protected $availableAttributes = [
@@ -31,7 +30,6 @@ class Tbody extends Element
         'enterkeyhint',
         'inputmode',
         'align',
-        'bgcolor'
+        'bgcolor',
     ];
-
 }

--- a/src/Elements/Td.php
+++ b/src/Elements/Td.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Td extends Element
 {
-
     protected $name = 'td';
 
     protected $availableAttributes = [
@@ -35,7 +34,6 @@ class Td extends Element
         'bgcolor',
         'colspan',
         'headers',
-        'rowspan'
+        'rowspan',
     ];
-
 }

--- a/src/Elements/Textarea.php
+++ b/src/Elements/Textarea.php
@@ -3,11 +3,9 @@
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Textarea extends Element
 {
-
     protected $name = 'textarea';
 
     protected $availableAttributes = [
@@ -46,7 +44,6 @@ class Textarea extends Element
         'readonly',
         'required',
         'rows',
-        'wrap'
+        'wrap',
     ];
-
 }

--- a/src/Elements/Tfoot.php
+++ b/src/Elements/Tfoot.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Tfoot extends Element
 {
-
     protected $name = 'tfoot';
 
     protected $availableAttributes = [
@@ -31,7 +30,6 @@ class Tfoot extends Element
         'enterkeyhint',
         'inputmode',
         'align',
-        'bgcolor'
+        'bgcolor',
     ];
-
 }

--- a/src/Elements/Th.php
+++ b/src/Elements/Th.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Th extends Element
 {
-
     protected $name = 'th';
 
     protected $availableAttributes = [
@@ -36,7 +35,6 @@ class Th extends Element
         'colspan',
         'headers',
         'rowspan',
-        'scope'
+        'scope',
     ];
-
 }

--- a/src/Elements/Thead.php
+++ b/src/Elements/Thead.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Thead extends Element
 {
-
     protected $name = 'thead';
 
     protected $availableAttributes = [
@@ -30,7 +29,6 @@ class Thead extends Element
         'translate',
         'enterkeyhint',
         'inputmode',
-        'align'
+        'align',
     ];
-
 }

--- a/src/Elements/Time.php
+++ b/src/Elements/Time.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Time extends Element
 {
-
     protected $name = 'time';
 
     protected $availableAttributes = [
@@ -30,7 +29,6 @@ class Time extends Element
         'translate',
         'enterkeyhint',
         'inputmode',
-        'datetime'
+        'datetime',
     ];
-
 }

--- a/src/Elements/Tr.php
+++ b/src/Elements/Tr.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Tr extends Element
 {
-
     protected $name = 'tr';
 
     protected $availableAttributes = [
@@ -31,7 +30,6 @@ class Tr extends Element
         'enterkeyhint',
         'inputmode',
         'align',
-        'bgcolor'
+        'bgcolor',
     ];
-
 }

--- a/src/Elements/Track.php
+++ b/src/Elements/Track.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
@@ -6,7 +7,6 @@ use YeTii\HtmlElement\Interfaces\IsSingleton;
 
 class Track extends Element implements IsSingleton
 {
-
     protected $name = 'track';
 
     protected $availableAttributes = [
@@ -34,7 +34,6 @@ class Track extends Element implements IsSingleton
         'kind',
         'label',
         'src',
-        'srclang'
+        'srclang',
     ];
-
 }

--- a/src/Elements/U.php
+++ b/src/Elements/U.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class U extends Element
 {
-
     protected $name = 'u';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class U extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Ul.php
+++ b/src/Elements/Ul.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Ul extends Element
 {
-
     protected $name = 'ul';
 
     protected $availableAttributes = [
@@ -29,7 +28,6 @@ class Ul extends Element
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Elements/Var.php
+++ b/src/Elements/Var.php
@@ -1,12 +1,12 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
-use YeTii\HtmlElement\Element;
 use YeTii\HtmlElement\Schema;
+use YeTii\HtmlElement\Element;
 
 class Var extends Element
 {
-
     protected $name = 'var';
 
     protected $availableAttributes = [
@@ -31,5 +31,4 @@ class Var extends Element
         'enterkeyhint',
         'inputmode'
     ];
-
 }

--- a/src/Elements/Video.php
+++ b/src/Elements/Video.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
-use YeTii\HtmlElement\Schema;
 
 class Video extends Element
 {
-
     protected $name = 'video';
 
     protected $availableAttributes = [
@@ -40,7 +39,6 @@ class Video extends Element
         'poster',
         'preload',
         'src',
-        'width'
+        'width',
     ];
-
 }

--- a/src/Elements/Wbr.php
+++ b/src/Elements/Wbr.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace YeTii\HtmlElement\Elements;
 
 use YeTii\HtmlElement\Element;
@@ -6,7 +7,6 @@ use YeTii\HtmlElement\Interfaces\IsSingleton;
 
 class Wbr extends Element implements IsSingleton
 {
-
     protected $name = 'wbr';
 
     protected $availableAttributes = [
@@ -29,7 +29,6 @@ class Wbr extends Element implements IsSingleton
         'title',
         'translate',
         'enterkeyhint',
-        'inputmode'
+        'inputmode',
     ];
-
 }

--- a/src/Exceptions/InvalidAttributeException.php
+++ b/src/Exceptions/InvalidAttributeException.php
@@ -1,11 +1,11 @@
 <?php
+
 namespace YeTii\HtmlElement\Exceptions;
 
 use Exception;
 
 class InvalidAttributeException extends Exception
 {
-
     protected $message = 'Invalid attribute for Element';
 
     protected $code = 8001;

--- a/src/Interfaces/HasTextChild.php
+++ b/src/Interfaces/HasTextChild.php
@@ -4,5 +4,4 @@ namespace YeTii\HtmlElement\Interfaces;
 
 interface HasTextChild
 {
-
 }

--- a/src/Interfaces/HasTextChild.php
+++ b/src/Interfaces/HasTextChild.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace YeTii\HtmlElement\Interfaces;
 
 interface HasTextChild

--- a/src/Interfaces/IsSingleton.php
+++ b/src/Interfaces/IsSingleton.php
@@ -4,5 +4,4 @@ namespace YeTii\HtmlElement\Interfaces;
 
 interface IsSingleton
 {
-
 }

--- a/src/Interfaces/IsSingleton.php
+++ b/src/Interfaces/IsSingleton.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace YeTii\HtmlElement\Interfaces;
 
 interface IsSingleton

--- a/src/Interfaces/IsTextNode.php
+++ b/src/Interfaces/IsTextNode.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace YeTii\HtmlElement\Interfaces;
 
 interface IsTextNode

--- a/src/Interfaces/IsTextNode.php
+++ b/src/Interfaces/IsTextNode.php
@@ -4,5 +4,4 @@ namespace YeTii\HtmlElement\Interfaces;
 
 interface IsTextNode
 {
-
 }

--- a/src/TextNode.php
+++ b/src/TextNode.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace YeTii\HtmlElement;
 
 use YeTii\HtmlElement\Element;

--- a/src/TextNode.php
+++ b/src/TextNode.php
@@ -2,19 +2,17 @@
 
 namespace YeTii\HtmlElement;
 
-use YeTii\HtmlElement\Element;
 use YeTii\HtmlElement\Interfaces\IsTextNode;
 
 class TextNode extends Element implements IsTextNode
 {
-
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected $name = '#text';
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function set(array $args): Element
     {

--- a/tests/Unit/ElementsTest.php
+++ b/tests/Unit/ElementsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace YeTii\HtmlElement\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
@@ -11,7 +12,6 @@ use YeTii\HtmlElement\TextNode;
 
 final class ElementsTest extends TestCase
 {
-
     /** @test */
     public function itCanRetrieveTheDefaultName(): void
     {

--- a/tests/Unit/ElementsTest.php
+++ b/tests/Unit/ElementsTest.php
@@ -3,12 +3,12 @@
 namespace YeTii\HtmlElement\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
-use YeTii\HtmlElement\Elements\B as Bold;
-use YeTii\HtmlElement\Elements\Div;
-use YeTii\HtmlElement\Elements\Input;
-use YeTii\HtmlElement\Elements\Span;
-use YeTii\HtmlElement\Elements\Textarea;
 use YeTii\HtmlElement\TextNode;
+use YeTii\HtmlElement\Elements\Div;
+use YeTii\HtmlElement\Elements\Span;
+use YeTii\HtmlElement\Elements\Input;
+use YeTii\HtmlElement\Elements\Textarea;
+use YeTii\HtmlElement\Elements\B as Bold;
 
 final class ElementsTest extends TestCase
 {

--- a/tests/Unit/ElementsTest.php
+++ b/tests/Unit/ElementsTest.php
@@ -274,7 +274,7 @@ final class ElementsTest extends TestCase
     }
 
     /** @test */
-    public function excplitlyDisablingEscapingOfHtmlOnTextNodeIsRespected(): void
+    public function explicitlyDisablingEscapingOfHtmlOnTextNodeIsRespected(): void
     {
         $child2 = new TextNode([
             'node' => '<b>test2</b>',


### PR DESCRIPTION
This PR:
- Updates to use the Laravel style formatting
- Fixes a typo in the `explicitlyDisablingEscapingOfHtmlOnTextNodeIsRespected()` test method
- Fixes spacing for some of the classes